### PR TITLE
Fix Experience Graphic (Line Not Going Through Circles)

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -180,7 +180,7 @@ import TravelMap from '../components/TravelMap.astro';
     padding: 0;
     margin: 0;
     position: relative;
-    padding-left: $logo-size + $spacing-unit * 2;
+    padding-left: 36px;
 
     @include mobile {
       width: fit-content;
@@ -202,7 +202,7 @@ import TravelMap from '../components/TravelMap.astro';
       position: absolute;
       left: $line-left;
       top: 0;
-      bottom: $logo-size * 0.5;
+      bottom: 24px;
       width: 2px;
       background: var(--color-text);
     }


### PR DESCRIPTION
Layout bug: somehow the vertical lines part of the About page Experience graphic are no longer touching. Either the line moved left of the rest of the graphic moved right. Two small CSS tweaks fixed it--but they're not hard-coded in px when they were a nice, clean  type deal. This is fine, because the CSS has gotten pretty 'manual 1px change here, 10px there' and needs a global overhaul using more consistent cross-site (relative distance) CSS numbers.