### PR TITLE
Add Costa Rica to travel map

### DIFF
--- a/src/components/TravelMap.astro
+++ b/src/components/TravelMap.astro
@@ -234,6 +234,9 @@ import austinShield from '../assets/austin-shield.svg';
     DO1: { name: 'Dominican Republic', flag: '\u{1F1E9}\u{1F1F4}' },
     KY1: { name: 'Cayman Islands', flag: '\u{1F1F0}\u{1F1FE}' },
 
+    // Central America
+    CR1: { name: 'Costa Rica', flag: '\u{1F1E8}\u{1F1F7}' },
+
     // South America
     BR1: { name: 'Brazil', flag: '\u{1F1E7}\u{1F1F7}' },
 


### PR DESCRIPTION
## Summary
- Add Costa Rica as a new destination on the travel map under a Central America section

## Changes
- Added Costa Rica entry (CR1) with flag emoji to TravelMap.astro
- Added "Central America" region comment for organization

## Testing
- Astro build passes cleanly

## Review Notes
- [ ] Code correctness and edge cases
- [ ] No hardcoded secrets or credentials
- [ ] Build passes