### PR TITLE
feat(rainbow): switch supergraphic stripe to four-color 70s palette

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -2,16 +2,14 @@
   role="img" aria-label="Mark McDermott">
     <defs>
       <linearGradient id="rainbow" x1="0" y1="0" x2="1" y2="0">
-        <stop offset="0%"   stop-color="#064cc1"/>
-        <stop offset="20%"  stop-color="#064cc1"/>
-        <stop offset="20%"  stop-color="#1976d2"/>
-        <stop offset="40%"  stop-color="#1976d2"/>
-        <stop offset="40%"  stop-color="#ffd100"/>
-        <stop offset="60%"  stop-color="#ffd100"/>
-        <stop offset="60%"  stop-color="#ff6a00"/>
-        <stop offset="80%"  stop-color="#ff6a00"/>
-        <stop offset="80%"  stop-color="#e53935"/>
-        <stop offset="100%" stop-color="#e53935"/>
+        <stop offset="0%"   stop-color="#065450"/>
+        <stop offset="25%"  stop-color="#065450"/>
+        <stop offset="25%"  stop-color="#d8391a"/>
+        <stop offset="50%"  stop-color="#d8391a"/>
+        <stop offset="50%"  stop-color="#f07f36"/>
+        <stop offset="75%"  stop-color="#f07f36"/>
+        <stop offset="75%"  stop-color="#f2b024"/>
+        <stop offset="100%" stop-color="#f2b024"/>
       </linearGradient>
     </defs>
     <rect width="32" height="32" fill="#faf7f0"/>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -13,8 +13,8 @@
     inset: 0 auto 0 0;            /* top:0; bottom:0; left:0 */
     width: clamp(16px, 2vw, 24px);
     background: linear-gradient(to right,
-      #064cc1 0% 20%, #1976d2 20% 40%, #ffd100 40% 60%,
-      #ff6a00 60% 80%, #e53935 80% 100%);
+      #065450 0% 25%, #d8391a 25% 50%,
+      #f07f36 50% 75%, #f2b024 75% 100%);
     z-index: 0;  
   }
 }


### PR DESCRIPTION
Changes the vertical supergraphic stripe on the left edge from five colors to four, using a saturated 70s palette.

## Palette

Ordered darkest to lightest, left to right:

| | Color | Hex | HSL |
|---|---|---|---|
| 1 | deep teal | `#065450` | h178 s91% l17% |
| 2 | vermilion | `#d8391a` | h11 s79% l47% |
| 3 | coral / rust-orange | `#f07f36` | h20 s86% l58% |
| 4 | marigold | `#f2b024` | h42 s89% l55% |

Saturation runs 79–91%. An earlier pass sampled directly from a reference image and landed at 40–52% saturation, which read as muddy — the desaturated warm tones all pulled toward brown.

## Notes

- Overall stripe width is unchanged (`clamp(16px, 2vw, 24px)`). Each band goes from 20% to 25% of that width, so the stripes get wider rather than the graphic getting narrower.
- All four bands stay distinct at the real 24px rendered width, not just when zoomed.
- `public/favicon.svg` renders the same gradient as a circle, so it is updated to match.
- Page background is untouched.

## Verification

`npm run build` passes; 39 pages built. Confirmed the compiled gradient in `dist/_astro/Layout.*.css`:

```
linear-gradient(90deg,#065450 0% 25%,#d8391a 25% 50%,#f07f36 50% 75%,#f2b024 75% 100%)
```