### PR TITLE
feat(about): add studio link to socials list

### DIFF
--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -3,6 +3,7 @@
     <li><a class="hover:border-b-2" href="https://mark-mcdermott.bsky.social/">Bluesky</a></li>
     <li><a class="hover:border-b-2" href="https://github.com/mark-mcdermott">Github</a></li>
     <li><a class="hover:border-b-2" href="https://www.linkedin.com/in/mark-mcdermott-6a174916/">Linkedin</a></li>
+    <li><a class="hover:border-b-2" href="https://mm.coffee/">Studio</a></li>
     <li><a class="hover:border-b-2" href="mailto:mark@markmcdermott.io">Email</a></li>
   </ul>
 </div>


### PR DESCRIPTION
Adds a **Studio** link to the About page socials list, pointing at https://mm.coffee/.

Positioned between Linkedin and Email:

```
Bluesky
Github
Linkedin
Studio     ← new
Email
```

## Notes

- Markup matches the surrounding links exactly, including the `hover:border-b-2` class. No `target`/`rel` attributes, since none of the other external links use them.
- `Socials.astro` is a shared component, but About is its only consumer, so the link does not appear anywhere else.

## Verification

`npm run build` passes; 39 pages built. Confirmed the link renders in the correct position in `dist/about/index.html`:

```html
<li><a class="hover:border-b-2" href="https://www.linkedin.com/in/mark-mcdermott-6a174916/">Linkedin</a></li>
<li><a class="hover:border-b-2" href="https://mm.coffee/">Studio</a></li>
<li><a class="hover:border-b-2" href="mailto:mark@markmcdermott.io">Email</a></li>
```